### PR TITLE
Add secondary docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 This project now provides two docker-compose configurations that can be started simultaneously.
 
 - `docker-compose.yaml` – default instance mapping ports `5432`, `7001`, `8001`.
-- `docker-compose.second.yaml` – secondary instance mapping ports `5433`, `7002`, `8002`.
+- `docker-compose.second.yaml` – secondary instance mapping ports `5434`, `7002`, `8002`.
 
 Each configuration defines its own containers, network and volume so they do not conflict.
 The second compose file also overrides the application database host so the app
 connects to its own `postgres2` service.
+
+Environment variables are loaded from `etc/config.env` by default. You can edit
+that file or provide custom values in the compose files. The secondary compose
+already sets `PG_HOST` to `postgres2` so it talks to its own database service.
 
 To start both:
 
@@ -20,6 +24,6 @@ docker compose -f docker-compose.second.yaml up -d
 ```
 
 Each instance has its own PostgreSQL volume (`pg-data` and `pg-data2`), providing isolated databases.
-If any of the mapped ports (`5433`, `7002`, `8002`) are in use on your host, edit
+If any of the mapped ports (`5434`, `7002`, `8002`) are in use on your host, edit
 `docker-compose.second.yaml` and change them to free ports before starting the
 stack.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project now provides two docker-compose configurations that can be started 
 - `docker-compose.second.yaml` – secondary instance mapping ports `5433`, `7002`, `8002`.
 
 Each configuration defines its own containers, network and volume so they do not conflict.
+The second compose file also overrides the application database host so the app
+connects to its own `postgres2` service.
 
 To start both:
 
@@ -18,3 +20,6 @@ docker compose -f docker-compose.second.yaml up -d
 ```
 
 Each instance has its own PostgreSQL volume (`pg-data` and `pg-data2`), providing isolated databases.
+If any of the mapped ports (`5433`, `7002`, `8002`) are in use on your host, edit
+`docker-compose.second.yaml` and change them to free ports before starting the
+stack.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Running multiple instances
+
+This project now provides two docker-compose configurations that can be started simultaneously.
+
+- `docker-compose.yaml` – default instance mapping ports `5432`, `7001`, `8001`.
+- `docker-compose.second.yaml` – secondary instance mapping ports `5433`, `7002`, `8002`.
+
+Each configuration defines its own containers, network and volume so they do not conflict.
+
+To start both:
+
+```bash
+# first instance
+docker compose -f docker-compose.yaml up -d
+
+# second instance
+docker compose -f docker-compose.second.yaml up -d
+```
+
+Each instance has its own PostgreSQL volume (`pg-data` and `pg-data2`), providing isolated databases.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project now provides two docker-compose configurations that can be started simultaneously.
 
 - `docker-compose.yaml` – default instance mapping ports `5432`, `7001`, `8001`.
-- `docker-compose.second.yaml` – secondary instance mapping ports `5434`, `7002`, `8002`.
+- `docker-compose.second.yaml` – secondary instance mapping ports `5434`, `7004`, `8002`.
 
 Each configuration defines its own containers, network and volume so they do not conflict.
 The second compose file also overrides the application database host so the app
@@ -24,6 +24,6 @@ docker compose -f docker-compose.second.yaml up -d
 ```
 
 Each instance has its own PostgreSQL volume (`pg-data` and `pg-data2`), providing isolated databases.
-If any of the mapped ports (`5434`, `7002`, `8002`) are in use on your host, edit
+If any of the mapped ports (`5434`, `7004`, `8002`) are in use on your host, edit
 `docker-compose.second.yaml` and change them to free ports before starting the
 stack.

--- a/docker-compose.second.yaml
+++ b/docker-compose.second.yaml
@@ -1,0 +1,107 @@
+networks:
+  net2:
+    driver: bridge
+
+services:
+  postgres:
+    container_name: postgres2
+    image: postgres
+    volumes:
+      - pg-data2:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_DB: 'db'
+      POSTGRES_INITDB_ARGS: '--auth-host=scram-sha-256'
+    ports:
+      - 5433:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d db"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+    networks:
+      - net2
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    deploy:
+      replicas: 1
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+    container_name: 'app-container2'
+    restart: always
+    hostname: server
+    environment:
+      ENV: "production"
+    ports:
+      - 7002:7001   # HTTP port
+      - 8002:8001   # HTTPS port
+    volumes:
+      - type: bind
+        source: ./certs
+        target: /ssl
+        read_only: true
+        bind:
+          create_host_path: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - net2
+  cleaner:
+    build:
+      context: .
+      dockerfile: Dockerfile.cleaner
+    container_name: 'cleaner-container2'
+    restart: always
+    environment:
+      ENV: "production"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - net2
+volumes:
+  pg-data2:
+
+

--- a/docker-compose.second.yaml
+++ b/docker-compose.second.yaml
@@ -14,7 +14,7 @@ services:
       POSTGRES_DB: 'db'
       POSTGRES_INITDB_ARGS: '--auth-host=scram-sha-256'
     ports:
-      - 5433:5432
+      - 5434:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d db"]
       interval: 30s

--- a/docker-compose.second.yaml
+++ b/docker-compose.second.yaml
@@ -60,6 +60,8 @@ services:
     hostname: server
     environment:
       ENV: "production"
+      PG_HOST: postgres2
+      PG_PORT: 5432
     ports:
       - 7002:7001   # HTTP port
       - 8002:8001   # HTTPS port
@@ -83,6 +85,8 @@ services:
     restart: always
     environment:
       ENV: "production"
+      PG_HOST: postgres2
+      PG_PORT: 5432
     deploy:
       resources:
         limits:

--- a/docker-compose.second.yaml
+++ b/docker-compose.second.yaml
@@ -63,7 +63,7 @@ services:
       PG_HOST: postgres2
       PG_PORT: 5432
     ports:
-      - 7002:7001   # HTTP port
+      - 7004:7001   # HTTP port
       - 8002:8001   # HTTPS port
     volumes:
       - type: bind


### PR DESCRIPTION
## Summary
- add `docker-compose.second.yaml` for a second isolated stack
- document how to run both compose files concurrently

## Testing
- `go test ./...` *(fails: forbidden download due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686a55f192308332ad9200cf65c6360c